### PR TITLE
fix master track visibility

### DIFF
--- a/Area51/Area_51_Refactor.lua
+++ b/Area51/Area_51_Refactor.lua
@@ -77,7 +77,8 @@ function GetTracksXYH()
    TBH = {}
    local _, x_view_start, y_view_start, x_view_end, y_view_end = reaper.JS_Window_GetRect(track_window)
    -- ONLY ADD MASTER TRACK IF VISIBLE IN TCP
-   if reaper.GetMasterTrackVisibility() == 1 then
+   local  master_tr_visibility = reaper.GetMasterTrackVisibility()
+   if master_tr_visibility == 1 or master_tr_visibility == 3 then
       local master_tr = reaper.GetMasterTrack(0)
       local m_tr_h = reaper.GetMediaTrackInfo_Value(master_tr, "I_TCPH")
       local m_tr_t = reaper.GetMediaTrackInfo_Value(master_tr, "I_TCPY") + y_view_start


### PR DESCRIPTION
**reaper.GetMasterTrackVisibility()** seems to return different values depending on whether the track is visible in the mixer or not.

Master track:
hidden in tcp, visible in mixer,  -----> 0
visible in tcp and the mixer -----> 1
hidden in tcp, hidden in mixer -----> 2
visible in tcp, hidden in mixer  ----->  3
