### PR TITLE
Move moving inside jobs

### DIFF
--- a/Area51/Area_51_class.lua
+++ b/Area51/Area_51_class.lua
@@ -42,7 +42,7 @@ function Element:zone(z)
       local tracks = z[5]
       local new_L = z[2] + mouse.dp >= 0 and z[2] + mouse.dp or 0
 
-      if not mouse.Ctrl() then -- DRAG COPY
+      if not mouse.Ctrl() and false then -- DRAG COPY, disabled updating area start while dragging
         --if not SPLIT then
           --AreaDo({self}, "split") -- split selection
           --self.sel_info = GetSelectionInfo(self) -- get new info on seleciton
@@ -118,12 +118,11 @@ function Element:zone(z)
         self.time_start = self.time_start >= 0 and self.time_start or 0
         self.x = convert_time_to_pixel(self.time_start, 0)
       else
-        --split_or_delete_items(nil, as_items_tbl, as_start, as_end, key)
-        --AreaDo({self}, "split") -- split selection
-        --self.sel_info = GetSelectionInfo(self) -- get new info on seleciton
-          --GetGhosts(self.sel_info, self.time_start, self.time_start + self.time_dur, "update", z[2])
-          --SPLIT = true --set split flag
-        move_items_envs(self, self.time_start - z[2]) -- MOVE ITEMS BEFORE WE UPDATE THE AREA SO OFFSET CAN REFRESH
+        local new_L = z[2] + mouse.dp >= 0 and z[2] + mouse.dp or 0
+        AreaDo({self}, "move",new_L)
+        self.time_start = new_L
+        self.time_start = self.time_start >= 0 and self.time_start or 0
+        self.x = convert_time_to_pixel(self.time_start, 0)
       end
       UnlinkGhosts()
       self.sel_info = GetSelectionInfo(self)

--- a/Area51/Area_51_functions.lua
+++ b/Area51/Area_51_functions.lua
@@ -350,7 +350,6 @@ function AreaDo(tbl, job, off)
     for i = 1, #tbl.sel_info do
       local info = tbl.sel_info[i]
       local first_tr = find_highest_tr(info.track)
-
       if info.items then
         local item_track = info.track
         local item_data = info.items
@@ -363,6 +362,10 @@ function AreaDo(tbl, job, off)
         if job == "stretch" then
           stretch_items(item_data, as_start, as_end)
         end
+        if job == "move" then
+          paste(info.items, item_track, as_start, as_end, pos_offset, first_tr,off)
+          split_or_delete_items(item_track, item_data, as_start, as_end , 'del')
+        end
       elseif info.env_name then
         local env_track = info.track
         local env_name = info.env_name
@@ -372,6 +375,11 @@ function AreaDo(tbl, job, off)
           paste_env(env_track, env_name, env_data, as_start, as_end, pos_offset, first_tr, #tbl.sel_info, off)
         end
         if job == "del" then
+          del_env(env_track, as_start, as_end, pos_offset, job)
+          reaper.Envelope_SortPoints(env_track)
+        end
+        if job == "move" then
+          paste_env(env_track, env_name, env_data, as_start, as_end, pos_offset, first_tr, #tbl.sel_info, off)
           del_env(env_track, as_start, as_end, pos_offset, job)
           reaper.Envelope_SortPoints(env_track)
         end


### PR DESCRIPTION
I made it so dragging an area does not update the start position of the area while dragging, it is the only way I was able to move it inside **AreaDo()** jobs. When I think about it makes sense to me (The area that is being dragged is a visual representation of what is going to happen, but the area is still actually where it is being dragged from)